### PR TITLE
Add missing includes

### DIFF
--- a/test/freelist_test.cpp
+++ b/test/freelist_test.cpp
@@ -12,6 +12,7 @@
 
 #include <boost/foreach.hpp>
 #include <boost/thread.hpp>
+#include <boost/scoped_ptr.hpp>
 
 #define BOOST_TEST_MAIN
 #ifdef BOOST_LOCKFREE_INCLUDE_TESTS
@@ -19,8 +20,6 @@
 #else
 #include <boost/test/unit_test.hpp>
 #endif
-
-#include <boost/foreach.hpp>
 
 #include <set>
 

--- a/test/queue_bounded_stress_test.cpp
+++ b/test/queue_bounded_stress_test.cpp
@@ -6,6 +6,8 @@
 
 #include <boost/lockfree/queue.hpp>
 
+#include <boost/scoped_ptr.hpp>
+
 #define BOOST_TEST_MAIN
 #ifdef BOOST_LOCKFREE_INCLUDE_TESTS
 #include <boost/test/included/unit_test.hpp>

--- a/test/queue_fixedsize_stress_test.cpp
+++ b/test/queue_fixedsize_stress_test.cpp
@@ -6,6 +6,8 @@
 
 #include <boost/lockfree/queue.hpp>
 
+#include <boost/scoped_ptr.hpp>
+
 #define BOOST_TEST_MAIN
 #ifdef BOOST_LOCKFREE_INCLUDE_TESTS
 #include <boost/test/included/unit_test.hpp>

--- a/test/queue_unbounded_stress_test.cpp
+++ b/test/queue_unbounded_stress_test.cpp
@@ -6,6 +6,8 @@
 
 #include <boost/lockfree/queue.hpp>
 
+#include <boost/scoped_ptr.hpp>
+
 #define BOOST_TEST_MAIN
 #ifdef BOOST_LOCKFREE_INCLUDE_TESTS
 #include <boost/test/included/unit_test.hpp>

--- a/test/stack_bounded_stress_test.cpp
+++ b/test/stack_bounded_stress_test.cpp
@@ -6,6 +6,8 @@
 
 #include <boost/lockfree/stack.hpp>
 
+#include <boost/scoped_ptr.hpp>
+
 #define BOOST_TEST_MAIN
 #ifdef BOOST_LOCKFREE_INCLUDE_TESTS
 #include <boost/test/included/unit_test.hpp>

--- a/test/stack_fixedsize_stress_test.cpp
+++ b/test/stack_fixedsize_stress_test.cpp
@@ -6,6 +6,8 @@
 
 #include <boost/lockfree/stack.hpp>
 
+#include <boost/scoped_ptr.hpp>
+
 #define BOOST_TEST_MAIN
 #ifdef BOOST_LOCKFREE_INCLUDE_TESTS
 #include <boost/test/included/unit_test.hpp>

--- a/test/stack_unbounded_stress_test.cpp
+++ b/test/stack_unbounded_stress_test.cpp
@@ -6,6 +6,8 @@
 
 #include <boost/lockfree/stack.hpp>
 
+#include <boost/scoped_ptr.hpp>
+
 #define BOOST_TEST_MAIN
 #ifdef BOOST_LOCKFREE_INCLUDE_TESTS
 #include <boost/test/included/unit_test.hpp>


### PR DESCRIPTION
This fixes the compile breaks in the regression tests.
