### PR TITLE
spsc_queue: fixed consume_all return value type

### DIFF
--- a/include/boost/lockfree/spsc_queue.hpp
+++ b/include/boost/lockfree/spsc_queue.hpp
@@ -463,13 +463,13 @@ public:
     }
 
     template <typename Functor>
-    bool consume_all(Functor & f)
+    size_type consume_all(Functor & f)
     {
         return ringbuffer_base<T>::consume_all(f, data(), max_size);
     }
 
     template <typename Functor>
-    bool consume_all(Functor const & f)
+    size_type consume_all(Functor const & f)
     {
         return ringbuffer_base<T>::consume_all(f, data(), max_size);
     }


### PR DESCRIPTION
When using the compile_time_sized_ringbuffer version of spsc_queue::consume_all, the value returned is a bool (similar to the way consume_one works) instead of the number of elements consumed (similar to the way the runtime_sized_ringbuffer version works).

This also generates the following warning in VS2012:
boost/lockfree/spsc_queue.hpp(473): warning C4800: 'boost::lockfree::detail::ringbuffer_base<T>::size_t' : forcing value to bool 'true' or 'false' (performance warning)
