### PR TITLE
Fix two VS2010 warnings caused by implicit widening followed by narrowing

### DIFF
--- a/include/boost/lockfree/detail/freelist.hpp
+++ b/include/boost/lockfree/detail/freelist.hpp
@@ -296,7 +296,7 @@ public:
 
     tag_t get_next_tag() const
     {
-        tag_t next = (get_tag() + 1) & (std::numeric_limits<tag_t>::max)();
+        tag_t next = (get_tag() + 1u) & (std::numeric_limits<tag_t>::max)();
         return next;
     }
 

--- a/include/boost/lockfree/detail/tagged_ptr_ptrcompression.hpp
+++ b/include/boost/lockfree/detail/tagged_ptr_ptrcompression.hpp
@@ -52,7 +52,7 @@ private:
         return cu.tag[tag_index];
     }
 
-    static compressed_ptr_t pack_ptr(T * ptr, int tag)
+    static compressed_ptr_t pack_ptr(T * ptr, tag_t tag)
     {
         cast_unit ret;
         ret.value = compressed_ptr_t(ptr);
@@ -132,7 +132,7 @@ public:
 
     tag_t get_next_tag() const
     {
-        tag_t next = (get_tag() + 1) & (std::numeric_limits<tag_t>::max)();
+        tag_t next = (get_tag() + 1u) & (std::numeric_limits<tag_t>::max)();
         return next;
     }
 


### PR DESCRIPTION
This change fixes the following warnings triggered by lockfree;

boost/lockfree/detail/freelist.hpp(299) : warning C4365: 'initializing' : conversion from 'int' to 'boost::lockfree::detail::tagged_index::tag_t', signed/unsigned mismatch
boost/lockfree/detail/tagged_ptr_ptrcompression.hpp(59) : warning C4242: '=' : conversion from 'int' to 'boost::lockfree::detail::tagged_ptr::tag_t', possible loss of data
boost/lockfree/detail/tagged_ptr_ptrcompression.hpp(59) : warning C4365: '=' : conversion from 'int' to 'boost::lockfree::detail::tagged_ptr::tag_t', signed/unsigned mismatch
boost/lockfree/detail/tagged_ptr_ptrcompression.hpp(135) : warning C4365: 'initializing' : conversion from 'int' to 'boost::lockfree::detail::tagged_ptr::tag_t', signed/unsigned mismatch
boost/lockfree/detail/tagged_ptr_ptrcompression.hpp(59) : warning C4242: '=' : conversion from 'int' to 'boost::lockfree::detail::tagged_ptr::tag_t', possible loss of data
boost/lockfree/detail/tagged_ptr_ptrcompression.hpp(59) : warning C4365: '=' : conversion from 'int' to 'boost::lockfree::detail::tagged_ptr::tag_t', signed/unsigned mismatch

This can be reproduced with the following minimal test;

// Compile with cl.exe /Wall /I%BOOST_ROOT% /EHsc /DBOOST_ALL_NO_LIB
#include

int main()
{
  boost::lockfree::stack s(32);
  return 0;
}