### PR TITLE
Add a check for begin == end to allow users to supply an empty list to lockfree::stack::push

### DIFF
--- a/include/boost/lockfree/stack.hpp
+++ b/include/boost/lockfree/stack.hpp
@@ -243,6 +243,11 @@ private:
     template <bool Threadsafe, bool Bounded, typename ConstIterator>
     tuple<node*, node*> prepare_node_list(ConstIterator begin, ConstIterator end, ConstIterator & ret)
     {
+        if (begin == end) {
+            ret = begin;
+            return make_tuple<node*, node*>(NULL, NULL);
+        }
+
         ConstIterator it = begin;
         node * end_node = pool.template construct<Threadsafe, Bounded>(*it++);
         if (end_node == NULL) {


### PR DESCRIPTION
I'm not 100% sure if this is desirable or not. A simple test is something like this;

#include <boost/lockfree/stack.hpp>

int main()
{
    boost::lockfree::stack<int> s(10);
    std::vector<int> v;
    s.push(v.begin(), v.end());
    return 0;
}

This will crash (in debug at least), when dereferencing the begin iterator. However, it's possible this is as designed because it's expected that the user doesn't supply an empty list. I'm OK with either, but did hit this today.