### PR TITLE
Add move-construction and emplacement support

### DIFF
--- a/include/boost/lockfree/spsc_queue.hpp
+++ b/include/boost/lockfree/spsc_queue.hpp
@@ -22,6 +22,7 @@
 
 #include <boost/type_traits/has_trivial_destructor.hpp>
 #include <boost/type_traits/is_convertible.hpp>
+#include <boost/type_traits/is_copy_constructible.hpp>
 
 #include <boost/lockfree/detail/atomic.hpp>
 #include <boost/lockfree/detail/copy_payload.hpp>
@@ -762,7 +763,7 @@ public:
      * */
 
     template<typename... Args>
-    typename std::enable_if< std::is_constructible<T, Args...>::value, bool>::type
+    typename boost::enable_if< typename boost::is_constructible<T, Args...>::type, bool>::type
     push(Args&&... args)
     {
         return base_type::push(std::forward<Args>(args)...);

--- a/include/boost/lockfree/spsc_queue.hpp
+++ b/include/boost/lockfree/spsc_queue.hpp
@@ -605,28 +605,28 @@ public:
     template <typename ConstIterator>
     ConstIterator push(ConstIterator begin, ConstIterator end)
     {
-        return ringbuffer_base<T>::push(begin, end, array_, max_elements_);
+        return ringbuffer_base<T>::push(begin, end, &*array_, max_elements_);
     }
 
     size_type pop(T * ret, size_type size)
     {
-        return ringbuffer_base<T>::pop(ret, size, array_, max_elements_);
+        return ringbuffer_base<T>::pop(ret, size, &*array_, max_elements_);
     }
 
     template <typename OutputIterator>
     size_type pop_to_output_iterator(OutputIterator it)
     {
-        return ringbuffer_base<T>::pop_to_output_iterator(it, array_, max_elements_);
+        return ringbuffer_base<T>::pop_to_output_iterator(it, &*array_, max_elements_);
     }
 
     const T& front(void) const
     {
-        return ringbuffer_base<T>::front(array_);
+        return ringbuffer_base<T>::front(&*array_);
     }
 
     T& front(void)
     {
-        return ringbuffer_base<T>::front(array_);
+        return ringbuffer_base<T>::front(&*array_);
     }
 };
 


### PR DESCRIPTION
It is in many cases more efficient to move construct or `emplace` an item using constructor arguments than it is to copy construct. As of now, the only way to `push` onto `spsc_queue` is via copy construction with placement new. Adding support for emplacement and move construction and detecting these features' compatibility with compilers can allow for newer users to take advantage of them while still maintaining support for users with older compilers. 
