### PR TITLE
lockfree: increase the lockfree cache line size for PowerPC

### DIFF
--- a/include/boost/lockfree/detail/prefix.hpp
+++ b/include/boost/lockfree/detail/prefix.hpp
@@ -13,7 +13,12 @@
                                    of the virtual address space as tag (at least 16bit)
 */
 
-#define BOOST_LOCKFREE_CACHELINE_BYTES 64
+// PowerPC caches support 128-byte cache lines.
+#if defined(powerpc) || defined(__powerpc__) || defined(__ppc__)
+    #define BOOST_LOCKFREE_CACHELINE_BYTES 128
+#else
+    #define BOOST_LOCKFREE_CACHELINE_BYTES 64
+#endif
 
 #include <boost/predef.h>
 


### PR DESCRIPTION
This is a simple patch to set the cache line size to 128 bytes on POWER.