### PR TITLE
Conditionally replace deprecated/removed std::auto_ptr by std::unique…

### DIFF
--- a/test/queue_test.cpp
+++ b/test/queue_test.cpp
@@ -163,7 +163,11 @@ BOOST_AUTO_TEST_CASE( queue_convert_pop_test )
     }
 
     {
+#ifdef BOOST_NO_AUTO_PTR
+        unique_ptr<int> i3;
+#else
         auto_ptr<int> i3;
+#endif
         BOOST_REQUIRE(f.pop(i3));
 
         BOOST_REQUIRE_EQUAL(*i3, 3);


### PR DESCRIPTION
…_ptr.

Signed-off-by: Daniela Engert <dani@ngrt.de>