### PR TITLE
lockfree: increase the lockfree cache line size for IBM Z

### DIFF
--- a/include/boost/lockfree/detail/prefix.hpp
+++ b/include/boost/lockfree/detail/prefix.hpp
@@ -13,8 +13,9 @@
                                    of the virtual address space as tag (at least 16bit)
 */
 
-// PowerPC caches support 128-byte cache lines.
-#if defined(powerpc) || defined(__powerpc__) || defined(__ppc__)
+#if defined(__s390__) || defined(__s390x__)
+    #define BOOST_LOCKFREE_CACHELINE_BYTES 256
+#elif defined(powerpc) || defined(__powerpc__) || defined(__ppc__)
     #define BOOST_LOCKFREE_CACHELINE_BYTES 128
 #else
     #define BOOST_LOCKFREE_CACHELINE_BYTES 64


### PR DESCRIPTION
The cache line size on IBM Z (s390, s390x) is 256 bytes.