### PR TITLE
Add allocator rebind helper to wrap the deprecated allocator::rebind in C++17

### DIFF
--- a/include/boost/lockfree/detail/allocator_rebind_helper.hpp
+++ b/include/boost/lockfree/detail/allocator_rebind_helper.hpp
@@ -1,0 +1,32 @@
+//  boost lockfree: allocator rebind helper
+//
+//  Copyright (C) 2017 Minmin Gong
+//
+//  Distributed under the Boost Software License, Version 1.0. (See
+//  accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_LOCKFREE_ALLOCATOR_REBIND_HELPER_HPP_INCLUDED
+#define BOOST_LOCKFREE_ALLOCATOR_REBIND_HELPER_HPP_INCLUDED
+
+#include <memory>
+
+namespace boost    {
+namespace lockfree {
+namespace detail   {
+
+template <class allocator_type, class value_type>
+struct allocator_rebind_helper
+{
+#if !defined( BOOST_NO_CXX11_ALLOCATOR )
+    typedef typename std::allocator_traits<allocator_type>::template rebind_alloc<value_type> type;
+#else
+    typedef typename allocator_type::template rebind<value_type>::other type;
+#endif
+};
+
+} /* namespace detail */
+} /* namespace lockfree */
+} /* namespace boost */
+
+#endif /* BOOST_LOCKFREE_ALLOCATOR_REBIND_HELPER_HPP_INCLUDED */

--- a/include/boost/lockfree/detail/parameter.hpp
+++ b/include/boost/lockfree/detail/parameter.hpp
@@ -15,6 +15,8 @@
 
 #include <boost/mpl/void.hpp>
 
+#include <boost/lockfree/detail/allocator_rebind_helper.hpp>
+
 
 namespace boost {
 namespace lockfree {
@@ -54,7 +56,7 @@ struct extract_allocator
                                std::allocator<T>
                               >::type allocator_arg;
 
-    typedef typename allocator_arg::template rebind<T>::other type;
+    typedef typename detail::allocator_rebind_helper<allocator_arg, T>::type type;
 };
 
 template <typename bound_args, bool default_ = false>

--- a/include/boost/lockfree/queue.hpp
+++ b/include/boost/lockfree/queue.hpp
@@ -17,6 +17,7 @@
 #include <boost/type_traits/has_trivial_destructor.hpp>
 #include <boost/config.hpp> // for BOOST_LIKELY & BOOST_ALIGNMENT
 
+#include <boost/lockfree/detail/allocator_rebind_helper.hpp>
 #include <boost/lockfree/detail/atomic.hpp>
 #include <boost/lockfree/detail/copy_payload.hpp>
 #include <boost/lockfree/detail/freelist.hpp>
@@ -189,7 +190,7 @@ public:
     }
 
     template <typename U>
-    explicit queue(typename node_allocator::template rebind<U>::other const & alloc):
+    explicit queue(typename detail::allocator_rebind_helper<node_allocator, U>::type const & alloc):
         head_(tagged_node_handle(0, 0)),
         tail_(tagged_node_handle(0, 0)),
         pool(alloc, capacity)
@@ -220,7 +221,7 @@ public:
     }
 
     template <typename U>
-    queue(size_type n, typename node_allocator::template rebind<U>::other const & alloc):
+    queue(size_type n, typename detail::allocator_rebind_helper<node_allocator, U>::type const & alloc):
         head_(tagged_node_handle(0, 0)),
         tail_(tagged_node_handle(0, 0)),
         pool(alloc, n + 1)

--- a/include/boost/lockfree/spsc_queue.hpp
+++ b/include/boost/lockfree/spsc_queue.hpp
@@ -24,6 +24,7 @@
 #include <boost/type_traits/has_trivial_destructor.hpp>
 #include <boost/type_traits/is_convertible.hpp>
 
+#include <boost/lockfree/detail/allocator_rebind_helper.hpp>
 #include <boost/lockfree/detail/atomic.hpp>
 #include <boost/lockfree/detail/copy_payload.hpp>
 #include <boost/lockfree/detail/parameter.hpp>
@@ -540,7 +541,7 @@ public:
     }
 
     template <typename U>
-    runtime_sized_ringbuffer(typename Alloc::template rebind<U>::other const & alloc, size_type max_elements):
+    runtime_sized_ringbuffer(typename detail::allocator_rebind_helper<Alloc, U>::type const & alloc, size_type max_elements):
         Alloc(alloc), max_elements_(max_elements + 1)
     {
         array_ = Alloc::allocate(max_elements_);
@@ -730,7 +731,7 @@ public:
     }
 
     template <typename U>
-    explicit spsc_queue(typename allocator::template rebind<U>::other const &)
+    explicit spsc_queue(typename detail::allocator_rebind_helper<allocator, U>::type const &)
     {
         // just for API compatibility: we don't actually need an allocator
         BOOST_STATIC_ASSERT(!runtime_sized);
@@ -756,7 +757,7 @@ public:
     }
 
     template <typename U>
-    spsc_queue(size_type element_count, typename allocator::template rebind<U>::other const & alloc):
+    spsc_queue(size_type element_count, typename detail::allocator_rebind_helper<allocator, U>::type const & alloc):
         base_type(alloc, element_count)
     {
         BOOST_STATIC_ASSERT(runtime_sized);

--- a/include/boost/lockfree/stack.hpp
+++ b/include/boost/lockfree/stack.hpp
@@ -15,6 +15,7 @@
 #include <boost/tuple/tuple.hpp>
 #include <boost/type_traits/is_copy_constructible.hpp>
 
+#include <boost/lockfree/detail/allocator_rebind_helper.hpp>
 #include <boost/lockfree/detail/atomic.hpp>
 #include <boost/lockfree/detail/copy_payload.hpp>
 #include <boost/lockfree/detail/freelist.hpp>
@@ -144,7 +145,7 @@ public:
     }
 
     template <typename U>
-    explicit stack(typename node_allocator::template rebind<U>::other const & alloc):
+    explicit stack(typename detail::allocator_rebind_helper<node_allocator, U>::type const & alloc):
         pool(alloc, capacity)
     {
         BOOST_STATIC_ASSERT(has_capacity);
@@ -169,7 +170,7 @@ public:
     }
 
     template <typename U>
-    stack(size_type n, typename node_allocator::template rebind<U>::other const & alloc):
+    stack(size_type n, typename detail::allocator_rebind_helper<node_allocator, U>::type const & alloc):
         pool(alloc, n)
     {
         BOOST_STATIC_ASSERT(!has_capacity);


### PR DESCRIPTION
In VS2017.5 with /std:c++17, allocator::rebind is deprecated. Add a helper to fix this.