### PR TITLE
minimal changes to allow single move only values to be pushed and popedminimal changes to allow single move only values to be pushed and poped (version 2)

### DIFF
--- a/include/boost/lockfree/detail/move_payload.hpp
+++ b/include/boost/lockfree/detail/move_payload.hpp
@@ -1,0 +1,75 @@
+//  boost lockfree: move_payload helper
+//
+//  Copyright (C) 2011 Tim Blechmann
+//
+//  Distributed under the Boost Software License, Version 1.0. (See
+//  accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_LOCKFREE_DETAIL_MOVE_PAYLOAD_HPP_INCLUDED
+#define BOOST_LOCKFREE_DETAIL_MOVE_PAYLOAD_HPP_INCLUDED
+
+#include <boost/mpl/if.hpp>
+#include <boost/type_traits/is_convertible.hpp>
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4512) // assignment operator could not be generated
+#endif
+
+namespace boost    {
+namespace lockfree {
+namespace detail   {
+
+struct move_convertible
+{
+    template <typename T, typename U>
+    static void move(T & t, U & u)
+    {
+        u = std::move(t);
+    }
+};
+
+struct move_constructible_and_assignable
+{
+    template <typename T, typename U>
+    static void ^move(T & t, U & u)
+    {
+        u = U(std::move(t));
+    }
+};
+
+template <typename T, typename U>
+void move_payload(T & t, U & u)
+{
+    typedef typename boost::mpl::if_<typename boost::is_convertible<T, U>::type,
+                                     move_convertible,
+                                     move_constructible_and_assignable
+                                    >::type move_type;
+    move_type::move(t, u);
+}
+
+template <typename T>
+struct consume_via_move
+{
+    consume_via_move(T & out):
+        out_(std::move(out))
+    {}
+
+    template <typename U>
+    void operator()(U & element)
+    {
+        move_payload(element, out_);
+    }
+
+    T & out_;
+};
+
+
+}}}
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+#endif  /* BOOST_LOCKFREE_DETAIL_COPY_PAYLOAD_HPP_INCLUDED */

--- a/include/boost/lockfree/detail/move_payload.hpp
+++ b/include/boost/lockfree/detail/move_payload.hpp
@@ -33,7 +33,7 @@ struct move_convertible
 struct move_constructible_and_assignable
 {
     template <typename T, typename U>
-    static void ^move(T & t, U & u)
+    static void move(T & t, U & u)
     {
         u = U(std::move(t));
     }
@@ -53,7 +53,7 @@ template <typename T>
 struct consume_via_move
 {
     consume_via_move(T & out):
-        out_(std::move(out))
+        out_(out)
     {}
 
     template <typename U>

--- a/test/spsc_queue_test.cpp
+++ b/test/spsc_queue_test.cpp
@@ -406,6 +406,7 @@ BOOST_AUTO_TEST_CASE( spsc_queue_reset_test )
     BOOST_REQUIRE(f.empty());
 }
 
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
 
 BOOST_AUTO_TEST_CASE( spsc_queue_unique_ptr_push_pop_test )
 {
@@ -433,3 +434,4 @@ BOOST_AUTO_TEST_CASE( spsc_queue_unique_ptr_push_pop_test )
     BOOST_REQUIRE(f.empty());
 }
 
+#endif

--- a/test/spsc_queue_test.cpp
+++ b/test/spsc_queue_test.cpp
@@ -16,8 +16,8 @@
 #include <iostream>
 #include <memory>
 
-#include "test_helpers.hpp"
 #include "test_common.hpp"
+#include "test_helpers.hpp"
 
 using namespace boost;
 using namespace boost::lockfree;
@@ -405,3 +405,31 @@ BOOST_AUTO_TEST_CASE( spsc_queue_reset_test )
 
     BOOST_REQUIRE(f.empty());
 }
+
+
+BOOST_AUTO_TEST_CASE( spsc_queue_unique_ptr_push_pop_test )
+{
+    spsc_queue<std::unique_ptr<int[]>, capacity<64> > f;
+
+    BOOST_REQUIRE(f.empty());
+   
+    unique_ptr<int[]> in;
+    unique_ptr<int[]> out;
+   
+    const int fortytwo = 42;
+   
+    in.reset( new int[1] );
+    in[0] = fortytwo;
+    int* data = in.get();
+   
+    BOOST_REQUIRE( f.push( std::move(in) ) );
+    BOOST_REQUIRE( f.pop(out) );
+
+    BOOST_REQUIRE( out.get() == data );
+    BOOST_REQUIRE( out[0] == fortytwo );
+
+    f.reset();
+
+    BOOST_REQUIRE(f.empty());
+}
+


### PR DESCRIPTION
I have made the requested changes. I have not managed to verify that this actually will compile with a C++03/C++98 compiler.