### PR TITLE
modify freelist_test.cpp/spsc_queue_stress_test.cpp/test_common.hpp to adapt VxWorks7

### DIFF
--- a/test/freelist_test.cpp
+++ b/test/freelist_test.cpp
@@ -190,6 +190,10 @@ struct freelist_tester
 
             if (running.load() == false)
                 break;
+
+#ifdef __VXWORKS__
+            boost::thread::yield();
+#endif
         }
 
         dummy * node;

--- a/test/spsc_queue_stress_test.cpp
+++ b/test/spsc_queue_stress_test.cpp
@@ -36,7 +36,12 @@ struct spsc_queue_tester
 
     boost::lockfree::detail::atomic<long> spsc_queue_cnt, received_nodes;
 
+// In VxWorks one RTP just supports 65535 objects
+#ifndef __VXWORKS__
     static_hashed_set<int, 1<<16 > working_set;
+#else
+    static_hashed_set<int, 1<<15 > working_set;
+#endif
 
     spsc_queue_tester(void):
         spsc_queue_cnt(0), received_nodes(0)
@@ -118,7 +123,13 @@ struct spsc_queue_tester_buffering
 
     boost::lockfree::detail::atomic<long> spsc_queue_cnt;
 
+// In VxWorks one RTP just supports 65535 objects
+#ifndef __VXWORKS__
     static_hashed_set<int, 1<<16 > working_set;
+#else
+    static_hashed_set<int, 1<<15 > working_set;
+#endif
+
     boost::lockfree::detail::atomic<size_t> received_nodes;
 
     spsc_queue_tester_buffering(void):

--- a/test/test_common.hpp
+++ b/test/test_common.hpp
@@ -51,11 +51,17 @@ struct queue_stress_tester
             assert(inserted);
 
             if (Bounded)
-                while(stk.bounded_push(id) == false)
-                    /*thread::yield()*/;
+                while(stk.bounded_push(id) == false) {
+#ifdef __VXWORKS__
+                    thread::yield();
+#endif
+                }
             else
-                while(stk.push(id) == false)
-                    /*thread::yield()*/;
+                while(stk.push(id) == false) {
+#ifdef __VXWORKS__
+                    thread::yield();
+#endif
+                }
             ++push_count;
         }
         writers_finished += 1;
@@ -90,6 +96,10 @@ struct queue_stress_tester
 
             if ( writers_finished.load() == writer_threads )
                 break;
+
+#ifdef __VXWORKS__
+            thread::yield();
+#endif
         }
 
         while (consume_element(q));


### PR DESCRIPTION
Why modify freelist_test.cpp and test_common.hpp :
In VxWorks Kernel, the re-schedule mechanism does not enable "round-robin" reschdule between the same priority tasks by default. So the case "stack_unbounded_stress_test" will lead to test case hang forever. Here's the details:

The test case creates 4 tasks as “Reader”, and then 4 tasks as “Writer”, all those 8 task has the same priority 220.
If the target has 2 cores, the first 2 reader tasks will occupy the cores by “while (1)” without yield, so the other 2 readers tasks and 4 writers tasks have no chance to be run.
This will lead to the test case loop forever , then the exp scrip will catch it and print “RTP Execution Timeout; rebooting”

The test case creates 4 tasks as “Reader”, and then 4 tasks as “Writer”, all those 8 task has the same priority 220 in VxWorks Kernel.
If the target has 2 cores, the first 2 reader tasks will occupy the cores by “while (1)” without yield, so the other 2 readers tasks and 4 writers tasks have no chance to be run.
This will lead to the test case loop forever without any ending.

Why modify spsc_queue_stress_test.cpp :
In VxWorks user-land task (Wind River calls it as RTP), the max number of objects (the internal data structure RTP uses) in one RTP is limited at most 65535.
When the test is selected to run, the C++ constructor will create 1<<16 number of mutex via "new spsc_queue_tester".
And after test1->run() is finished, the C++ destructor will delete 1<<16 number of mutex by default.
This caused the problem, because VxWorks just support ((1<<16)-1) objects within an RTP.