### PR TITLE
Adjust to changes in Boost.Parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,6 +87,8 @@ install:
   - cd ..
   - git clone -b $BOOST_BRANCH https://github.com/boostorg/boost.git boost-root
   - cd boost-root
+  - git submodule update --init tools/boost_install
+  - git submodule update --init libs/headers
   - git submodule update --init tools/build
   - git submodule update --init libs/config
   - git submodule update --init tools/boostdep

--- a/include/boost/lockfree/detail/parameter.hpp
+++ b/include/boost/lockfree/detail/parameter.hpp
@@ -34,7 +34,7 @@ public:
     static const bool has_capacity = _has_capacity::value;
 
     typedef typename boost::mpl::eval_if<
-        typename boost::mpl::has_key<bound_args, tag::capacity>::type
+        _has_capacity
       , boost::parameter::binding<bound_args, tag::capacity>
       , boost::mpl::size_t< 0 >
     >::type capacity_t;
@@ -53,7 +53,7 @@ public:
     static const bool has_allocator = _has_allocator::value;
 
     typedef typename boost::mpl::eval_if<
-        typename boost::mpl::has_key<bound_args, tag::allocator>::type
+        _has_allocator
       , boost::parameter::binding<bound_args, tag::allocator>
       , boost::mpl::identity<std::allocator<T> >
     >::type allocator_arg;
@@ -71,7 +71,7 @@ public:
     static const bool has_fixed_sized = _has_fixed_sized::value;
 
     typedef typename mpl::eval_if<
-        typename boost::mpl::has_key<bound_args, tag::fixed_sized>::type
+        _has_fixed_sized
       , boost::parameter::binding<bound_args, tag::fixed_sized>
       , boost::mpl::bool_<default_>
     >::type type;

--- a/include/boost/lockfree/detail/parameter.hpp
+++ b/include/boost/lockfree/detail/parameter.hpp
@@ -46,7 +46,7 @@ template <typename bound_args, typename T>
 struct extract_allocator
 {
 private:
-    typedef typename boost::mpl::has_key<bound_args, tag::allocator>::type _has_allocator;
+    typedef typename mpl::has_key<bound_args, tag::allocator>::type _has_allocator;
 
 public:
     static const bool has_allocator = _has_allocator::value;
@@ -63,7 +63,7 @@ template <typename bound_args, bool default_ = false>
 struct extract_fixed_sized
 {
 private:
-    typedef typename boost::mpl::has_key<bound_args, tag::fixed_sized>::type _has_fixed_sized;
+    typedef typename mpl::has_key<bound_args, tag::fixed_sized>::type _has_fixed_sized;
 
 public:
     static const bool has_fixed_sized = _has_fixed_sized::value;

--- a/include/boost/lockfree/detail/parameter.hpp
+++ b/include/boost/lockfree/detail/parameter.hpp
@@ -28,16 +28,15 @@ template <typename bound_args>
 struct extract_capacity
 {
 private:
-    typedef typename boost::mpl::has_key<bound_args, tag::capacity>::type _has_capacity;
+    typedef typename mpl::has_key<bound_args, tag::capacity>::type _has_capacity;
 
 public:
     static const bool has_capacity = _has_capacity::value;
 
-    typedef typename boost::mpl::eval_if<
-        _has_capacity
-      , boost::parameter::binding<bound_args, tag::capacity>
-      , boost::mpl::size_t< 0 >
-    >::type capacity_t;
+    typedef typename mpl::eval_if<_has_capacity,
+                                  parameter::binding<bound_args, tag::capacity>,
+                                  mpl::size_t< 0 >
+                                 >::type capacity_t;
 
     static const std::size_t capacity = capacity_t::value;
 };
@@ -52,11 +51,10 @@ private:
 public:
     static const bool has_allocator = _has_allocator::value;
 
-    typedef typename boost::mpl::eval_if<
-        _has_allocator
-      , boost::parameter::binding<bound_args, tag::allocator>
-      , boost::mpl::identity<std::allocator<T> >
-    >::type allocator_arg;
+    typedef typename mpl::eval_if<_has_allocator,
+                                  parameter::binding<bound_args, tag::allocator>,
+                                  mpl::identity<std::allocator<T> >
+                                 >::type allocator_arg;
 
     typedef typename detail::allocator_rebind_helper<allocator_arg, T>::type type;
 };
@@ -70,11 +68,10 @@ private:
 public:
     static const bool has_fixed_sized = _has_fixed_sized::value;
 
-    typedef typename mpl::eval_if<
-        _has_fixed_sized
-      , boost::parameter::binding<bound_args, tag::fixed_sized>
-      , boost::mpl::bool_<default_>
-    >::type type;
+    typedef typename mpl::eval_if<_has_fixed_sized,
+                                  parameter::binding<bound_args, tag::fixed_sized>,
+                                  mpl::bool_<default_>
+                                 >::type type;
 
     static const bool value = type::value;
 };

--- a/include/boost/lockfree/policies.hpp
+++ b/include/boost/lockfree/policies.hpp
@@ -9,7 +9,7 @@
 #ifndef BOOST_LOCKFREE_POLICIES_HPP_INCLUDED
 #define BOOST_LOCKFREE_POLICIES_HPP_INCLUDED
 
-#include <boost/parameter/aux_/template_keyword.hpp>
+#include <boost/parameter/template_keyword.hpp>
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/size_t.hpp>
 


### PR DESCRIPTION
<boost/lockfree/policies.hpp>
* Change include statement to reflect the fact that the boost::parameter::template_keyword class template was moved to <boost/parameter/template_keyword.hpp>.

<boost/lockfree/detail/parameter.hpp>
* Use boost::mpl::has_key vice boost::lockfree::detail::has_arg.