### PR TITLE
Adding ptr compression support to MSVC ARM64 architecture

### DIFF
--- a/include/boost/lockfree/detail/prefix.hpp
+++ b/include/boost/lockfree/detail/prefix.hpp
@@ -23,7 +23,7 @@
 
 #include <boost/predef.h>
 
-#if BOOST_ARCH_X86_64 || defined (__aarch64__)
+#if BOOST_ARCH_X86_64 || defined (__aarch64__) || defined(_M_ARM64)
 #define BOOST_LOCKFREE_PTR_COMPRESSION 1
 #endif
 

--- a/include/boost/lockfree/detail/tagged_ptr_ptrcompression.hpp
+++ b/include/boost/lockfree/detail/tagged_ptr_ptrcompression.hpp
@@ -19,7 +19,7 @@ namespace boost {
 namespace lockfree {
 namespace detail {
 
-#if BOOST_ARCH_X86_64 || defined (__aarch64__)
+#if BOOST_ARCH_X86_64 || defined (__aarch64__) || defined(_M_ARM64)
 
 template <class T>
 class tagged_ptr


### PR DESCRIPTION
Support of pointer compression has already been added to gcc (__ aarch64 __ define). MSVC compiler doesn't provide the __ aarch64 __ define on ARM64 architecture. Instead of that it provides _M_ARM64.

The reasoning to add pointer compression support is for the lockfree queue is when the element type of the queue is pointer type. Currently when the queue is using tag_ptr wrapper for the queue node the tag_ptr wrapper doubles the size of the pointer and thus exchange operations  cannot be atomic (std::atomic::is_lock_free returns false). That makes lockfree queue is not lockfree (queue::is_lock_free returns false).
By setting BOOST_LOCKFREE_PTR_COMPRESSION 1 define we tell the compiler to include tagged_ptr_ptrcompression.hpp file instead of tagged_ptr_dcas.hpp. tagged_ptr_ptrcompression.hpp keeps the pointer size intact by using bits manipulation to keep tag field within 64bits.

The versification is done on the 16.4 MSVC compiler and Amberwing ARM64 CPU platform.