### PR TITLE
prefix: detect armv8 via boost.predef

### DIFF
--- a/include/boost/lockfree/detail/prefix.hpp
+++ b/include/boost/lockfree/detail/prefix.hpp
@@ -23,7 +23,7 @@
 
 #include <boost/predef.h>
 
-#if BOOST_ARCH_X86_64 || defined (__aarch64__)
+#if BOOST_ARCH_X86_64 || (BOOST_ARCH_ARM >= BOOST_VERSION_NUMBER(8,0,0))
 #define BOOST_LOCKFREE_PTR_COMPRESSION 1
 #endif
 

--- a/include/boost/lockfree/detail/tagged_ptr_ptrcompression.hpp
+++ b/include/boost/lockfree/detail/tagged_ptr_ptrcompression.hpp
@@ -19,7 +19,7 @@ namespace boost {
 namespace lockfree {
 namespace detail {
 
-#if BOOST_ARCH_X86_64 || defined (__aarch64__)
+#ifdef BOOST_LOCKFREE_PTR_COMPRESSION
 
 template <class T>
 class tagged_ptr


### PR DESCRIPTION
@mishatal could you possibly check this on your CPU? i'd rather use boost.predef for detecting armv8