### PR TITLE
stack, spsc_queue: don't create temporaries when deleting elements

### DIFF
--- a/include/boost/lockfree/spsc_queue.hpp
+++ b/include/boost/lockfree/spsc_queue.hpp
@@ -352,9 +352,8 @@ public:
         if ( !boost::has_trivial_destructor<T>::value ) {
             // make sure to call all destructors!
 
-            T dummy_element;
-            while (pop(dummy_element))
-            {}
+            detail::consume_noop consume_functor;
+            (void)consume_all( consume_functor );
         } else {
             write_index_.store(0, memory_order_relaxed);
             read_index_.store(0, memory_order_release);
@@ -451,8 +450,8 @@ protected:
     ~compile_time_sized_ringbuffer(void)
     {
         // destroy all remaining items
-        T out;
-        while (pop(&out, 1)) {}
+        detail::consume_noop consume_functor;
+        (void)consume_all(consume_functor);
     }
 
 public:
@@ -583,8 +582,8 @@ public:
     ~runtime_sized_ringbuffer(void)
     {
         // destroy all remaining items
-        T out;
-        while (pop(&out, 1)) {}
+        detail::consume_noop consume_functor;
+        (void)consume_all(consume_functor);
 
 #ifdef BOOST_NO_CXX11_ALLOCATOR
         Alloc::deallocate(array_, max_elements_);
@@ -1039,9 +1038,8 @@ public:
         if ( !boost::has_trivial_destructor<T>::value ) {
             // make sure to call all destructors!
 
-            T dummy_element;
-            while (pop(dummy_element))
-            {}
+            detail::consume_noop consume_functor;
+            (void)consume_all(consume_functor);
         } else {
             base_type::write_index_.store(0, memory_order_relaxed);
             base_type::read_index_.store(0, memory_order_release);

--- a/include/boost/lockfree/stack.hpp
+++ b/include/boost/lockfree/stack.hpp
@@ -237,9 +237,8 @@ public:
      * */
     ~stack(void)
     {
-        T dummy;
-        while(unsynchronized_pop(dummy))
-        {}
+        detail::consume_noop consume_functor;
+        (void)consume_all(consume_functor);
     }
 
 private:

--- a/test/destructor_test.cpp
+++ b/test/destructor_test.cpp
@@ -80,3 +80,71 @@ BOOST_AUTO_TEST_CASE( spsc_queue_fixed_sized_instance_deleter_test )
     assert(g_instance_counter == 0);
     BOOST_REQUIRE(g_instance_counter == 0);
 }
+
+struct no_default_init_tester
+{
+    int value;
+
+    no_default_init_tester(int value) : value(value)
+    {
+        ++g_instance_counter;
+    }
+
+    no_default_init_tester(no_default_init_tester const& t)
+    {
+        value = t.value;
+
+        ++g_instance_counter;
+    }
+
+    ~no_default_init_tester()
+    {
+        --g_instance_counter;
+    }
+};
+
+BOOST_AUTO_TEST_CASE( stack_instance_deleter_no_default_init_test )
+{
+    {
+        boost::lockfree::stack<no_default_init_tester> q(128);
+        q.push(no_default_init_tester(1));
+        q.push(no_default_init_tester(2));
+        q.push(no_default_init_tester(3));
+        q.push(no_default_init_tester(4));
+        q.push(no_default_init_tester(5));
+    }
+
+    assert(g_instance_counter == 0);
+    BOOST_REQUIRE(g_instance_counter == 0);
+}
+
+
+BOOST_AUTO_TEST_CASE( spsc_queue_instance_deleter_no_default_init_test )
+{
+    {
+        boost::lockfree::spsc_queue<no_default_init_tester> q(128);
+        q.push(no_default_init_tester(1));
+        q.push(no_default_init_tester(2));
+        q.push(no_default_init_tester(3));
+        q.push(no_default_init_tester(4));
+        q.push(no_default_init_tester(5));
+    }
+
+    assert(g_instance_counter == 0);
+    BOOST_REQUIRE(g_instance_counter == 0);
+}
+
+BOOST_AUTO_TEST_CASE( spsc_queue_fixed_sized_instance_deleter_no_default_init_test )
+{
+    {
+        boost::lockfree::spsc_queue<no_default_init_tester, boost::lockfree::capacity<128> > q;
+        q.push(no_default_init_tester(1));
+        q.push(no_default_init_tester(2));
+        q.push(no_default_init_tester(3));
+        q.push(no_default_init_tester(4));
+        q.push(no_default_init_tester(5));
+    }
+
+    assert(g_instance_counter == 0);
+    BOOST_REQUIRE(g_instance_counter == 0);
+}


### PR DESCRIPTION
When destructors/reset() are called temporary object was being created.
That creates issues when element doesn't have default initialization
(e.g. Boost.Interprocess containers).