### PR TITLE
Fix C++20 ambiguous comparison warning

### DIFF
--- a/include/boost/lockfree/detail/tagged_ptr_ptrcompression.hpp
+++ b/include/boost/lockfree/detail/tagged_ptr_ptrcompression.hpp
@@ -97,12 +97,12 @@ public:
 
     /** comparing semantics */
     /* @{ */
-    bool operator== (volatile tagged_ptr const & p) const
+    bool operator== (volatile tagged_ptr const & p) volatile const
     {
         return (ptr == p.ptr);
     }
 
-    bool operator!= (volatile tagged_ptr const & p) const
+    bool operator!= (volatile tagged_ptr const & p) volatile const
     {
         return !operator==(p);
     }


### PR DESCRIPTION
Swapping lhs/rhs should be the same, so marking the function as volatile fixes this.

This fixes:
```
warning: ISO C++20 considers use of overloaded operator '==' (with operand types 'A' and 'A') to be ambiguous despite there being a unique best viable function [-Wambiguous-reversed-operator]
```