### PR TITLE
queue: allow non-trivially moveable types

### DIFF
--- a/include/boost/lockfree/lockfree_forward.hpp
+++ b/include/boost/lockfree/lockfree_forward.hpp
@@ -39,7 +39,7 @@ struct allocator;
 template < typename T, typename... Options >
 #    if !defined( BOOST_NO_CXX20_HDR_CONCEPTS )
     requires( std::is_copy_assignable_v< T >,
-              std::is_trivially_assignable_v< T&, T >,
+              std::is_trivially_copy_assignable_v< T >,
               std::is_trivially_destructible_v< T > )
 #    endif
 class queue;

--- a/include/boost/lockfree/queue.hpp
+++ b/include/boost/lockfree/queue.hpp
@@ -77,14 +77,14 @@ typedef parameter::parameters< boost::parameter::optional< tag::allocator >, boo
  *
  *  \b Requirements:
  *   - T must have a copy constructor
- *   - T must have a trivial assignment operator
+ *   - T must have a trivial copy assignment operator
  *   - T must have a trivial destructor
  *
  * */
 template < typename T, typename... Options >
 #if !defined( BOOST_NO_CXX20_HDR_CONCEPTS )
     requires( std::is_copy_assignable_v< T >,
-              std::is_trivially_assignable_v< T&, T >,
+              std::is_trivially_copy_assignable_v< T >,
               std::is_trivially_destructible_v< T > )
 #endif
 class queue
@@ -93,7 +93,7 @@ private:
 #ifndef BOOST_DOXYGEN_INVOKED
 
     BOOST_STATIC_ASSERT( ( std::is_trivially_destructible< T >::value ) );
-    BOOST_STATIC_ASSERT( ( std::is_trivially_assignable< T&, T >::value ) );
+    BOOST_STATIC_ASSERT( ( std::is_trivially_copy_assignable< T >::value ) );
 
     typedef typename detail::queue_signature::bind< Options... >::type bound_args;
 


### PR DESCRIPTION
Restores the requirements prior to commit 6a70a658 which replaced boost::has_trivial_assign with std::is_trivially_assignable.

The latter trait requires both trivial copy and move assignment while the original only required trivial copy assignment. Since the lockfree queue doesn't require trivial move assignment, the requirement is being reverted back to the original.

Also updated the documentation to clarify only trivial copy assignment is needed.

Fixes #117