### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,6 @@ target_link_libraries(boost_lockfree
     Boost::core
     Boost::parameter
     Boost::predef
-    Boost::static_assert
     Boost::utility
 )
 

--- a/build.jam
+++ b/build.jam
@@ -13,7 +13,6 @@ constant boost_dependencies :
     /boost/core//boost_core
     /boost/parameter//boost_parameter
     /boost/predef//boost_predef
-    /boost/static_assert//boost_static_assert
     /boost/type_traits//boost_type_traits ;
 
 project /boost/lockfree

--- a/test/cmake_subdir_test/CMakeLists.txt
+++ b/test/cmake_subdir_test/CMakeLists.txt
@@ -20,7 +20,6 @@ set(deps
     mpl
     parameter
     predef
-    static_assert
     tuple
     type_traits
     utility


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.