### PR TITLE
share ABA prevention tag between freelist and queue

### DIFF
--- a/include/boost/lockfree/detail/freelist.hpp
+++ b/include/boost/lockfree/detail/freelist.hpp
@@ -80,8 +80,11 @@ public:
     T* construct( void )
     {
         T* node = allocate< ThreadSafe, Bounded >();
-        if ( node )
-            new ( node ) T();
+        if ( node ) {
+            freelist_node*  fn  = reinterpret_cast< freelist_node* >( node );
+            tagged_node_ptr old = fn->next;
+            new ( node ) T( old.get_next_tag() );
+        }
         return node;
     }
 
@@ -89,8 +92,11 @@ public:
     T* construct( ArgumentType&& arg )
     {
         T* node = allocate< ThreadSafe, Bounded >();
-        if ( node )
-            new ( node ) T( std::forward< ArgumentType >( arg ) );
+        if ( node ) {
+            freelist_node*  fn  = reinterpret_cast< freelist_node* >( node );
+            tagged_node_ptr old = fn->next;
+            new ( node ) T( std::forward< ArgumentType >( arg ), old.get_next_tag() );
+        }
         return node;
     }
 
@@ -98,8 +104,12 @@ public:
     T* construct( ArgumentType1&& arg1, ArgumentType2&& arg2 )
     {
         T* node = allocate< ThreadSafe, Bounded >();
-        if ( node )
-            new ( node ) T( std::forward< ArgumentType1 >( arg1 ), std::forward< ArgumentType2 >( arg2 ) );
+        if ( node ) {
+            freelist_node*  fn  = reinterpret_cast< freelist_node* >( node );
+            tagged_node_ptr old = fn->next;
+            new ( node )
+                T( std::forward< ArgumentType1 >( arg1 ), std::forward< ArgumentType2 >( arg2 ), old.get_next_tag() );
+        }
         return node;
     }
 
@@ -440,8 +450,9 @@ public:
         if ( node_index == null_handle() )
             return NULL;
 
-        T* node = NodeStorage::nodes() + node_index;
-        new ( node ) T();
+        T*             node = NodeStorage::nodes() + node_index;
+        freelist_node* fn   = reinterpret_cast< freelist_node* >( node );
+        new ( node ) T( fn->next.get_next_tag() );
         return node;
     }
 
@@ -452,8 +463,9 @@ public:
         if ( node_index == null_handle() )
             return NULL;
 
-        T* node = NodeStorage::nodes() + node_index;
-        new ( node ) T( std::forward< ArgumentType >( arg ) );
+        T*             node = NodeStorage::nodes() + node_index;
+        freelist_node* fn   = reinterpret_cast< freelist_node* >( node );
+        new ( node ) T( std::forward< ArgumentType >( arg ), fn->next.get_next_tag() );
         return node;
     }
 
@@ -464,8 +476,10 @@ public:
         if ( node_index == null_handle() )
             return NULL;
 
-        T* node = NodeStorage::nodes() + node_index;
-        new ( node ) T( std::forward< ArgumentType1 >( arg1 ), std::forward< ArgumentType2 >( arg2 ) );
+        T*             node = NodeStorage::nodes() + node_index;
+        freelist_node* fn   = reinterpret_cast< freelist_node* >( node );
+        new ( node )
+            T( std::forward< ArgumentType1 >( arg1 ), std::forward< ArgumentType2 >( arg2 ), fn->next.get_next_tag() );
         return node;
     }
 

--- a/include/boost/lockfree/queue.hpp
+++ b/include/boost/lockfree/queue.hpp
@@ -109,20 +109,19 @@ private:
         typedef typename detail::select_tagged_handle< node, node_based >::tagged_handle_type tagged_node_handle;
         typedef typename detail::select_tagged_handle< node, node_based >::handle_type        handle_type;
 
-        node( T const& v, handle_type null_handle ) :
+        template < typename TagT >
+        node( T const& v, handle_type null_handle, TagT next_tag ) :
+            next( tagged_node_handle( null_handle, next_tag ) ),
             data( v )
-        {
-            /* increment tag to avoid ABA problem */
-            tagged_node_handle old_next = next.load( memory_order_relaxed );
-            tagged_node_handle new_next( null_handle, old_next.get_next_tag() );
-            next.store( new_next, memory_order_release );
-        }
-
-        node( handle_type null_handle ) :
-            next( tagged_node_handle( null_handle, 0 ) )
         {}
 
-        node( void )
+        template < typename TagT >
+        node( handle_type null_handle, TagT next_tag ) :
+            next( tagged_node_handle( null_handle, next_tag ) )
+        {}
+
+        template < typename TagT >
+        node( TagT /*next_tag*/ )
         {}
 
         alignas( detail::cacheline_bytes ) atomic< tagged_node_handle > next;

--- a/include/boost/lockfree/stack.hpp
+++ b/include/boost/lockfree/stack.hpp
@@ -83,11 +83,13 @@ private:
 
     struct BOOST_MAY_ALIAS node
     {
-        node( const T& val ) :
+        template < typename TagT >
+        node( const T& val, TagT /*next_tag*/ ) :
             v( val )
         {}
 
-        node( T&& val ) :
+        template < typename TagT >
+        node( T&& val, TagT /*next_tag*/ ) :
             v( std::forward< T >( val ) )
         {}
 

--- a/test/freelist_test.cpp
+++ b/test/freelist_test.cpp
@@ -36,6 +36,14 @@ struct dummy
         allocated = 1;
     }
 
+    template < typename TagT >
+    dummy( TagT /*tag*/ )
+    {
+        if ( test_running.load( boost::lockfree::detail::memory_order_relaxed ) )
+            assert( allocated == 0 );
+        allocated = 1;
+    }
+
     ~dummy( void )
     {
         if ( test_running.load( boost::lockfree::detail::memory_order_relaxed ) )


### PR DESCRIPTION
passing the ABA prevention tag from freelist to queue (and stack) nodes prevents some overly eager optimizations